### PR TITLE
Doc: add info about sandbox setting on macOS in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ struct MyView: View {
 
 See the online [getting started guide][Getting-Started] for more information.
 
+For a sandboxed application (default on macOS) please don't forget to allow for printing in the target's "Signing & Capabilities" > "App Sandbox" section or you'll be met with the error "This application does not support printing.".
+
 
 
 ## Documentation


### PR DESCRIPTION
I'm not sure whether you think the README is the correct spot, but I stumbled over this and think it would have been nice to see this mentioned somewhere. Perhaps the Getting Started documentation is a better spot for this?