### PR TITLE
Doc: sandbox-settings on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ struct MyView: View {
 
 See the online [getting started guide][Getting-Started] for more information.
 
+For a sandboxed application (default on macOS) please don't forget to allow for printing in the target's "Signing & Capabilities" > "App Sandbox" section or you'll be met with the error "This application does not support printing.".
+
 
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -65,7 +65,11 @@ struct MyView: View {
 
 PrintingKit also has PDF utilities, which are used to print certain types. Since these utilies are the only ones that support paper size, page margins, etc. we should aim to make more print functions use PDF as print format.
 
-For a sandboxed application (default on macOS) please don't forget to allow for printing in the target's "Signing & Capabilities" > "App Sandbox" section or you'll be met with the error "This application does not support printing.".
+
+
+## macOS Sandbox Configuration
+
+For a sandboxed application (default on macOS) don't forget to allow for printing in the target's "Signing & Capabilities" > "App Sandbox" section or you'll be met with the error "This application does not support printing.".
 
 
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,11 @@ struct MyView: View {
 
 See the online [getting started guide][Getting-Started] for more information.
 
-For a sandboxed application (default on macOS) please don't forget to allow for printing in the target's "Signing & Capabilities" > "App Sandbox" section or you'll be met with the error "This application does not support printing.".
+
+
+## macOS Sandbox Configuration
+
+For a sandboxed application (default on macOS) don't forget to allow for printing in the target's "Signing & Capabilities" > "App Sandbox" section or you'll be met with the error "This application does not support printing.".
 
 
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ struct MyView: View {
 
 PrintingKit also has PDF utilities, which are used to print certain types. Since these utilies are the only ones that support paper size, page margins, etc. we should aim to make more print functions use PDF as print format.
 
+For a sandboxed application (default on macOS) please don't forget to allow for printing in the target's "Signing & Capabilities" > "App Sandbox" section or you'll be met with the error "This application does not support printing.".
+
 
 
 ## Documentation

--- a/Sources/PrintingKit/PrintingKit.docc/Getting-Started.md
+++ b/Sources/PrintingKit/PrintingKit.docc/Getting-Started.md
@@ -60,3 +60,10 @@ This will show a print dialog that you can use to perform the print operation, o
 ## PDF support
 
 PrintingKit also has ``Pdf`` utilities, that can be used to configure a PDF documentations, page margins, etc. They're used by the SDK when printing ``PrintItem/pdfData(_:)`` and ``PrintItem/pdfFile(at:)``, but you can use then as standalone utilities as well.
+
+
+## Configuring your project for macOS
+
+There are two settings that are manadatory for a sandboxed application on macOS (which is default). In the target's "Signing & Capabilities" > "App Sandbox" section 
+1. check the "Printer" checkbox or you'll be met with the error "This application does not support printing." and
+2. set the "User Selected File" type under "File Access" to "Read/Write", or the error "Unable to display save panel …" will show up

--- a/Sources/PrintingKit/PrintingKit.docc/Getting-Started.md
+++ b/Sources/PrintingKit/PrintingKit.docc/Getting-Started.md
@@ -64,6 +64,7 @@ PrintingKit also has ``Pdf`` utilities, that can be used to configure a PDF docu
 
 ## Configuring your project for macOS
 
-There are two settings that are manadatory for a sandboxed application on macOS (which is default). In the target's "Signing & Capabilities" > "App Sandbox" section 
+There are two settings that are manadatory for a sandboxed application on macOS (which is default). In the target's "Signing & Capabilities" > "App Sandbox" section
+
 1. check the "Printer" checkbox or you'll be met with the error "This application does not support printing." and
 2. set the "User Selected File" type under "File Access" to "Read/Write", or the error "Unable to display save panel …" will show up


### PR DESCRIPTION
For (perhaps a little bit more unexperienced) users on macOS, it might be useful to add info to the documentation on that printing support on that platform needs to be given explicitly in a sandboxed environment.

I am one of those rather inexperienced users, and even though I found out, it could have saved me some time if I had read it in the README or the documentation.

This is my second attempt for a PR, due to a rename on the branch the first PR got closed automagically … (sorry for the confusion and the delay)

Let me know if my PR needs improvements.
Appreciate your work, thanks for all the cool packages you are maintaining!